### PR TITLE
Update myAuto.ahk

### DIFF
--- a/myAuto.ahk
+++ b/myAuto.ahk
@@ -10,4 +10,4 @@ SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
 !s::Send {Media_Play_Pause}
 !d::Send {Media_Next}
 
-# test com
+# test comsdghyf


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

This PR introduces a single comment line following the media control hotkey definitions in myAuto.ahk. The line uses '#' instead of the correct AutoHotkey comment syntax (';'), which does not affect code functionality but is inconsistent with AHK standards.

*This summary was automatically generated by @propel-code-bot*